### PR TITLE
ignoring static folder for github linguistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+static/* linguist-vendored


### PR DESCRIPTION
Added a .gitattribute file so linguistics ignores the static folder. This removes the JavaScript language details.
#8
